### PR TITLE
support .ignoreme marker file to skip addon folder updates

### DIFF
--- a/src/CoffeeUpdater/Utils/AddOnBundleInstaller.cs
+++ b/src/CoffeeUpdater/Utils/AddOnBundleInstaller.cs
@@ -73,6 +73,12 @@ public class AddOnBundleInstaller
                     var sourceDir = _fileSystem.Path.Combine(stagingPath, folder);
                     var targetDir = _fileSystem.Path.Combine(addOnsPath, folder);
 
+                    if (HasIgnoreMarker(targetDir))
+                    {
+                        Log.Information("Skipping install of folder '{Folder}' because .ignoreme exists", folder);
+                        continue;
+                    }
+
                     if (_fileSystem.Directory.Exists(targetDir))
                     {
                         _fileSystem.Directory.Delete(targetDir, true);
@@ -107,10 +113,22 @@ public class AddOnBundleInstaller
             var addOnPath = _fileSystem.Path.Combine(_config.AddOnsPath, folder);
             if (_fileSystem.Directory.Exists(addOnPath))
             {
+                if (HasIgnoreMarker(addOnPath))
+                {
+                    Log.Information("Skipping uninstall of folder '{Folder}' because .ignoreme exists", folder);
+                    continue;
+                }
                 _fileSystem.Directory.Delete(addOnPath, true);
                 Log.Information("Uninstalled addon folder '{Folder}'", folder);
             }
         }
         _config.RemoveInstalledFolders(name);
+    }
+
+    private bool HasIgnoreMarker(string folderPath)
+    {
+        if (!_fileSystem.Directory.Exists(folderPath))
+            return false;
+        return _fileSystem.File.Exists(_fileSystem.Path.Combine(folderPath, ".ignoreme"));
     }
 }

--- a/src/CoffeeUpdater/Utils/AddOnUpdateManager.cs
+++ b/src/CoffeeUpdater/Utils/AddOnUpdateManager.cs
@@ -136,6 +136,11 @@ public class AddOnUpdateManager
                         var orphanPath = _fileSystem.Path.Combine(_config.AddOnsPath, orphan);
                         if (_fileSystem.Directory.Exists(orphanPath))
                         {
+                            if (_fileSystem.File.Exists(_fileSystem.Path.Combine(orphanPath, ".ignoreme")))
+                            {
+                                Log.Information("Skipping orphan folder '{Folder}' because .ignoreme exists", orphan);
+                                continue;
+                            }
                             _fileSystem.Directory.Delete(orphanPath, true);
                             Log.Information("Removed orphaned addon folder '{Folder}'", orphan);
                         }

--- a/tests/CoffeeUpdater.Tests/AddOnBundleInstallerTest.cs
+++ b/tests/CoffeeUpdater.Tests/AddOnBundleInstallerTest.cs
@@ -299,6 +299,113 @@ public class AddOnBundleInstallerTest
     }
 
     [Test]
+    public void InstallAddOn_IgnoreMePresent_SkipsFolderAndPreservesUserFiles()
+    {
+        var addOnName = "MyAddOn";
+        var targetDir = _env.FileSystem.Path.Combine(_addOnsPath, addOnName);
+        _env.FileSystem.Directory.CreateDirectory(targetDir);
+        _env.FileSystem.File.WriteAllText(_env.FileSystem.Path.Combine(targetDir, ".ignoreme"), "");
+        _env.FileSystem.File.WriteAllText(_env.FileSystem.Path.Combine(targetDir, "dev.lua"), "local dev content");
+
+        var bundle = CreateBundle(addOnName, ["file1.lua"]);
+        var result = _installer.InstallAddOn(bundle);
+
+        Assert.That(result, Is.EqualTo(new[] { addOnName }));
+        Assert.That(_env.FileSystem.File.ReadAllText(_env.FileSystem.Path.Combine(targetDir, "dev.lua")), Is.EqualTo("local dev content"));
+        Assert.That(_env.FileSystem.File.Exists(_env.FileSystem.Path.Combine(targetDir, "file1.lua")), Is.False);
+        Assert.That(_env.FileSystem.File.Exists(_env.FileSystem.Path.Combine(targetDir, ".ignoreme")), Is.True);
+    }
+
+    [Test]
+    public void InstallAddOn_MultiFolderBundle_IgnoreMeInOneFolder_SkipsOnlyThatFolder()
+    {
+        foreach (var folder in new[] { "BigWigs", "BigWigs_Options", "BigWigs_Plugins" })
+        {
+            var dir = _env.FileSystem.Path.Combine(_addOnsPath, folder);
+            _env.FileSystem.Directory.CreateDirectory(dir);
+            _env.FileSystem.File.WriteAllText(_env.FileSystem.Path.Combine(dir, "old.lua"), $"old {folder}");
+        }
+
+        var ignoredDir = _env.FileSystem.Path.Combine(_addOnsPath, "BigWigs_Options");
+        _env.FileSystem.File.WriteAllText(_env.FileSystem.Path.Combine(ignoredDir, ".ignoreme"), "");
+        _env.FileSystem.File.WriteAllText(_env.FileSystem.Path.Combine(ignoredDir, "dev.lua"), "dev work");
+
+        var bundle = CreateMultiFolderBundle("BigWigs", new Dictionary<string, string[]>
+        {
+            ["BigWigs"] = ["BigWigs.toc", "Core.lua"],
+            ["BigWigs_Options"] = ["Options.toc"],
+            ["BigWigs_Plugins"] = ["Plugins.toc"],
+        });
+
+        var result = _installer.InstallAddOn(bundle);
+
+        Assert.That(result, Is.EquivalentTo(new[] { "BigWigs", "BigWigs_Options", "BigWigs_Plugins" }));
+
+        var bigWigsDir = _env.FileSystem.Path.Combine(_addOnsPath, "BigWigs");
+        Assert.That(_env.FileSystem.File.Exists(_env.FileSystem.Path.Combine(bigWigsDir, "BigWigs.toc")), Is.True);
+        Assert.That(_env.FileSystem.File.Exists(_env.FileSystem.Path.Combine(bigWigsDir, "old.lua")), Is.False);
+
+        Assert.That(_env.FileSystem.File.ReadAllText(_env.FileSystem.Path.Combine(ignoredDir, "dev.lua")), Is.EqualTo("dev work"));
+        Assert.That(_env.FileSystem.File.ReadAllText(_env.FileSystem.Path.Combine(ignoredDir, "old.lua")), Is.EqualTo("old BigWigs_Options"));
+        Assert.That(_env.FileSystem.File.Exists(_env.FileSystem.Path.Combine(ignoredDir, "Options.toc")), Is.False);
+        Assert.That(_env.FileSystem.File.Exists(_env.FileSystem.Path.Combine(ignoredDir, ".ignoreme")), Is.True);
+
+        var pluginsDir = _env.FileSystem.Path.Combine(_addOnsPath, "BigWigs_Plugins");
+        Assert.That(_env.FileSystem.File.Exists(_env.FileSystem.Path.Combine(pluginsDir, "Plugins.toc")), Is.True);
+        Assert.That(_env.FileSystem.File.Exists(_env.FileSystem.Path.Combine(pluginsDir, "old.lua")), Is.False);
+    }
+
+    [Test]
+    public void InstallAddOn_IgnoreMePresent_DoesNotCreateGitDirectory()
+    {
+        var addOnName = "MyAddOn";
+        var targetDir = _env.FileSystem.Path.Combine(_addOnsPath, addOnName);
+        _env.FileSystem.Directory.CreateDirectory(targetDir);
+        _env.FileSystem.File.WriteAllText(_env.FileSystem.Path.Combine(targetDir, ".ignoreme"), "");
+
+        _installer.InstallAddOn(CreateBundle(addOnName, ["file1.lua"]));
+
+        Assert.That(_env.FileSystem.Directory.Exists(_env.FileSystem.Path.Combine(targetDir, ".git")), Is.False);
+    }
+
+    [Test]
+    public void UninstallAddOn_IgnoreMePresent_PreservesFolder()
+    {
+        var addOnDir = _env.FileSystem.Path.Combine(_addOnsPath, "MyAddOn");
+        _env.FileSystem.Directory.CreateDirectory(addOnDir);
+        _env.FileSystem.File.WriteAllText(_env.FileSystem.Path.Combine(addOnDir, ".ignoreme"), "");
+        _env.FileSystem.File.WriteAllText(_env.FileSystem.Path.Combine(addOnDir, "dev.lua"), "dev");
+
+        _installer.UninstallAddOn("MyAddOn");
+
+        Assert.That(_env.FileSystem.Directory.Exists(addOnDir), Is.True);
+        Assert.That(_env.FileSystem.File.ReadAllText(_env.FileSystem.Path.Combine(addOnDir, "dev.lua")), Is.EqualTo("dev"));
+    }
+
+    [Test]
+    public void UninstallAddOn_MultiFolderBundle_IgnoreMeInOneFolder_PreservesOnlyThatFolder()
+    {
+        _config.SetInstalledFolders("BigWigs", ["BigWigs", "BigWigs_Options", "BigWigs_Plugins"]);
+
+        foreach (var folder in new[] { "BigWigs", "BigWigs_Options", "BigWigs_Plugins" })
+        {
+            var dir = _env.FileSystem.Path.Combine(_addOnsPath, folder);
+            _env.FileSystem.Directory.CreateDirectory(dir);
+            _env.FileSystem.File.WriteAllText(_env.FileSystem.Path.Combine(dir, "file.lua"), "content");
+        }
+
+        var ignoredDir = _env.FileSystem.Path.Combine(_addOnsPath, "BigWigs_Plugins");
+        _env.FileSystem.File.WriteAllText(_env.FileSystem.Path.Combine(ignoredDir, ".ignoreme"), "");
+
+        _installer.UninstallAddOn("BigWigs");
+
+        Assert.That(_env.FileSystem.Directory.Exists(_env.FileSystem.Path.Combine(_addOnsPath, "BigWigs")), Is.False);
+        Assert.That(_env.FileSystem.Directory.Exists(_env.FileSystem.Path.Combine(_addOnsPath, "BigWigs_Options")), Is.False);
+        Assert.That(_env.FileSystem.Directory.Exists(ignoredDir), Is.True);
+        Assert.That(_env.FileSystem.File.Exists(_env.FileSystem.Path.Combine(ignoredDir, "file.lua")), Is.True);
+    }
+
+    [Test]
     public void InstallAddOn_EmptyBundle_ThrowsInvalidOperationException()
     {
         var memoryStream = new MemoryStream();

--- a/tests/CoffeeUpdater.Tests/AddOnUpdateManagerTest.cs
+++ b/tests/CoffeeUpdater.Tests/AddOnUpdateManagerTest.cs
@@ -447,6 +447,36 @@ public class AddOnUpdateManagerTest
         Assert.That(_config.InstalledAddOnFolders.ContainsKey("BigWigs"), Is.False);
     }
 
+    [Test]
+    public async Task UpdateAddOns_Update_OrphanWithIgnoreMe_IsPreserved()
+    {
+        _config.SetInstalledFolders("BigWigs", ["BigWigs", "BigWigs_Options", "BigWigs_OldPlugin"]);
+
+        var orphanPath = Path.Combine(AddOnsPath, "BigWigs_OldPlugin");
+        _mockEnv.FileSystem.Directory.CreateDirectory(orphanPath);
+        _mockEnv.FileSystem.File.WriteAllText(Path.Combine(orphanPath, ".ignoreme"), "");
+        _mockEnv.FileSystem.File.WriteAllText(Path.Combine(orphanPath, "dev.lua"), "dev work");
+
+        SetupLocalAddOn("BigWigs", "1.0.0");
+
+        var manifest = new AddOnManifest
+        {
+            AddOns = [new AddOnMetadata { Name = "BigWigs", Version = "2.0.0" }]
+        };
+        _mockDownloader.SetManifest(manifest);
+        _mockDownloader.AddMultiFolderBundle("BigWigs", "2.0.0", new Dictionary<string, string[]>
+        {
+            ["BigWigs"] = ["BigWigs.toc"],
+            ["BigWigs_Options"] = ["Options.toc"],
+        });
+
+        await _updateManager.UpdateAddOns();
+
+        Assert.That(_mockEnv.FileSystem.Directory.Exists(orphanPath), Is.True);
+        Assert.That(_mockEnv.FileSystem.File.ReadAllText(Path.Combine(orphanPath, "dev.lua")), Is.EqualTo("dev work"));
+        Assert.That(_config.InstalledAddOnFolders["BigWigs"], Is.EquivalentTo(new[] { "BigWigs", "BigWigs_Options" }));
+    }
+
     private void SetupLocalAddOn(string name, string version)
     {
         var addOnPath = Path.Combine(AddOnsPath, name);


### PR DESCRIPTION
A .ignoreme file placed in an addon folder protects that folder from
being overwritten or deleted by the updater. Useful for running a
locally-built dev version of an addon. Applies per-folder, so in a
multi-addon bundle (e.g. BigWigs + BigWigs_Options + BigWigs_Plugins)
only the marked folder is skipped; the rest update normally. Also
respected by the uninstall and orphan-cleanup paths.