### PR TITLE
Add M33kAuras to third-party addon sync list

### DIFF
--- a/scripts/sync-third-party-addons.js
+++ b/scripts/sync-third-party-addons.js
@@ -24,6 +24,7 @@ const s3Client = new S3({
 
 const ADDONS = [
     { name: "BigWigs", repo: "BigWigsMods/BigWigs" },
+    { name: "M33kAuras", repo: "m33shoq/M33kAuras" },
     { name: "NorthernSkyRaidTools", repo: "Reloe/NorthernSkyRaidTools" },
     { name: "RCLootCouncil", repo: "evil-morfar/RCLootCouncil2" },
 ];


### PR DESCRIPTION
Includes m33shoq/M33kAuras releases in the manifest sync so the addon is
auto-distributed to clients. Asset naming matches the existing
{Name}-{Tag}.zip convention.

https://claude.ai/code/session_01BCsPdiL7DBeFt7w6XkhuDp